### PR TITLE
Update to use FACTS v1.1.2 "global only"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Once this config is created, you can proceed to the **Running SC-GHGs** step.
 
 If you will be running FACTS, ensure you have followed the **Formatting GMST/GMSL files** section above. 
 
-We recommend installing or cloning FACTS v1.1.1 found [here](https://github.com/radical-collaboration/facts/releases/tag/v1.1.1). To get started with FACTS, follow the [FACTS quick start instructions](https://fact-sealevel.readthedocs.io/en/latest/quickstart.html). If you are running on a Linux machine (quickstart Section 1.1), proceed to the **Not Docker** section below. If you are running in a Container (quickstart Section 1.2), proceed to the **Docker** section below. We recommend reading these sections before following the FACTS quickstart. Note that to run `facts` for DSCIM-FACTS-EPA, you will *not* need to set up the `emulandice` module in facts.
+We recommend installing or cloning FACTS v1.1.2 found [here](https://github.com/radical-collaboration/facts/releases/tag/v1.1.2). To get started with FACTS, follow the [FACTS quick start instructions](https://fact-sealevel.readthedocs.io/en/latest/quickstart.html). If you are running on a Linux machine (quickstart Section 1.1), proceed to the **Not Docker** section below. If you are running in a Container (quickstart Section 1.2), proceed to the **Docker** section below. We recommend reading these sections before following the FACTS quickstart. Note that to run `facts` for DSCIM-FACTS-EPA, you will *not* need to set up the `emulandice` module in facts.
 
 ### Docker
 

--- a/scripts/facts.runs/template/config.yml
+++ b/scripts/facts.runs/template/config.yml
@@ -12,6 +12,7 @@ climate_step:
     dummy:
         module_set: "facts"
         module: "dummy"
+        pipeline_file: 'pipeline.yml'
         input_data_file:
             - "ohc.nc4"
             - "gsat.nc4"
@@ -57,7 +58,7 @@ sealevel_step:
     ar5AIS:
         module_set: "ipccar5"
         module: "icesheets"
-        pipeline_file: "pipeline.AIS.yml"
+        pipeline_file: "pipeline.AIS.global.yml"
         options_allowoverwrite:
             climate_data_file: "%CLIMATE_DATA_FILE%"
         include_in_workflow:
@@ -68,13 +69,6 @@ sealevel_step:
         module: "sterodynamics"
         options_allowoverwrite:
             climate_data_file: "%CLIMATE_DATA_FILE%"
-        include_in_workflow:
-            - "wf1f"
-            - "wf2f"
-
-    k14vlm:
-        module_set: "kopp14"
-        module: "verticallandmotion"
         include_in_workflow:
             - "wf1f"
             - "wf2f"

--- a/scripts/facts.runs/template/config.yml
+++ b/scripts/facts.runs/template/config.yml
@@ -5,6 +5,7 @@ global-options:
     pyear_end: 2300
     pyear_step: 1
     baseyear: 2005
+    pipeline_file: 'pipeline.global.yml'
 
 
 climate_step:


### PR DESCRIPTION
This update provides instructions and updates needed for running "global only" FACTS (introduced in v1.1.2)

This reduces the amount of input data needed to run FACTS and should reduce its runtime.