### PR TITLE
Add option to run risk neutral SCGHGS

### DIFF
--- a/scripts/batch_scghg.py
+++ b/scripts/batch_scghg.py
@@ -27,6 +27,9 @@ if __name__ == "__main__":
         "labor",
     ]
 
+    # Risk options to save out
+    risk_options = ["risk_aversion", "risk_neutral", ]
+
     # Pulse years to save out
     # pulse years should be present in climate files
     pulse_years = [
@@ -105,8 +108,8 @@ if __name__ == "__main__":
     if len(etas_rhos) == 0:
         raise ValueError("You must select at least one eta, rho combination")
 
-    risk_combos = [["risk_aversion", "euler_ramsey"]]  # Default
-
+    risk_combos = [[ro, "euler_ramsey"] for ro in risk_options]
+ 
     for dom in domains_ls:
         locale = "Territory US" if dom else "Global"
         print("=========================")

--- a/scripts/command_line_scghg.py
+++ b/scripts/command_line_scghg.py
@@ -43,6 +43,17 @@ if __name__ == "__main__":
             ],
         ),
         inquirer.Checkbox(
+            "menu_option",
+            message="Select risk type",
+            choices=[
+                ("Risk Aversion", "risk_aversion"),
+                ("Risk Neutral", "risk_neutral"),
+            ],
+            default=[
+                "risk_aversion",
+            ],
+        ),
+        inquirer.Checkbox(
             "eta_rhos",
             message="Select discount rates",
             choices=[
@@ -83,6 +94,7 @@ if __name__ == "__main__":
     answers = inquirer.prompt(questions)
     eta_rhos = answers["eta_rhos"]
     sector = answers["sector"]
+    menu_options = answers["menu_option"]
     pulse_years = answers["pulse_year"]
     terr_us_ls = answers["U.S."]
     gcnp = True if "gcnp" in answers["files"] else False
@@ -98,7 +110,7 @@ if __name__ == "__main__":
         if gas not in gas_conversion_dict.keys():
             gas_conversion_dict[gas] = gas
 
-    risk_combos = [["risk_aversion", "euler_ramsey"]]  # Default
+    risk_combos = [[mo, "euler_ramsey"] for mo in menu_options]
 
     for terr_us in terr_us_ls:
         locale = "Territory US" if terr_us else "Global"

--- a/scripts/command_line_scghg.py
+++ b/scripts/command_line_scghg.py
@@ -23,6 +23,17 @@ if __name__ == "__main__":
     pulse_year_choices = [(str(i), i) for i in pulse_years]
     questions = [
         inquirer.Checkbox(
+            "menu_option",
+            message="Select risk type (If choosing Risk Neutral, the only available sector is Combined)",
+            choices=[
+                ("Risk Aversion", "risk_aversion"),
+                ("Risk Neutral", "risk_neutral"),
+            ],
+            default=[
+                "risk_aversion",
+            ],
+        ),
+        inquirer.Checkbox(
             "sector",
             message="Select sector",
             choices=[
@@ -40,17 +51,6 @@ if __name__ == "__main__":
                 # "mortality_v" + mortality_v,
                 # "energy",
                 # "labor",
-            ],
-        ),
-        inquirer.Checkbox(
-            "menu_option",
-            message="Select risk type",
-            choices=[
-                ("Risk Aversion", "risk_aversion"),
-                ("Risk Neutral", "risk_neutral"),
-            ],
-            default=[
-                "risk_aversion",
             ],
         ),
         inquirer.Checkbox(

--- a/scripts/directory_setup.py
+++ b/scripts/directory_setup.py
@@ -47,7 +47,7 @@ conf_base = {'mortality_version': 1,
   
 # Download inputs from internet  
 print("Downloading input files...")
-name = 'dscim-v20250219_inputs.zip'
+name = 'dscim-v20250223_inputs.zip'
 url = 'https://storage.googleapis.com/climateimpactlab-scc-tool/dscim-facts-epa_input_data/' + name
 with requests.get(url, stream = True) as r:
     r.raise_for_status()

--- a/scripts/directory_setup.py
+++ b/scripts/directory_setup.py
@@ -47,7 +47,7 @@ conf_base = {'mortality_version': 1,
   
 # Download inputs from internet  
 print("Downloading input files...")
-name = 'dscim-v20240414_inputs.zip'
+name = 'dscim-v20250219_inputs.zip'
 url = 'https://storage.googleapis.com/climateimpactlab-scc-tool/dscim-facts-epa_input_data/' + name
 with requests.get(url, stream = True) as r:
     r.raise_for_status()

--- a/scripts/scghg_utils.py
+++ b/scripts/scghg_utils.py
@@ -405,6 +405,11 @@ def epa_scghgs(
             all_arrays_uscghg = []
             all_arrays_gcnp = []
 
+            if (menu_option == "risk_neutral") and ("CAMEL" not in sector):
+                import warnings
+                warnings.warn(f"Risk neutral SCGHGs are only available for the Combined sector. Skipping {sector}...")
+                continue
+            
             if re.split("_", sector)[0] == "CAMEL":
                 sector_short = "combined"
             else:


### PR DESCRIPTION
Added logic to calculate risk neutral SCGHGs to command line tool, batch run tool, and utility functions. Code changes allow for handling of "risk_neutral" ("adding_up" under the hood) option. 

Risk Neutral only works for "Combined" SCGHGs. Added a user warning if sector isn't Combined and risk option is "risk_neutral".