### PR TITLE
Add damage functions documentation

### DIFF
--- a/DAMAGE_FUNCTIONS.md
+++ b/DAMAGE_FUNCTIONS.md
@@ -2,7 +2,7 @@
 
 This document provides detailed documentation for the pre-computed damage function coefficients distributed with DSCIM-FACTS-EPA. These coefficients are the core input for translating climate projections (global mean surface temperature and global mean sea level) into monetized climate damages used to compute the Social Cost of Greenhouse Gases (SC-GHG).
 
-The damage functions were estimated by the Climate Impact Lab (CIL) using the Data-driven Spatial Climate Impact Model (DSCIM). The underlying model computes sector-specific climate damages at roughly 24,000 impact regions worldwide, then aggregates them to the global (or national) level. The coefficients provided here are the result of fitting quadratic regression functions to those globally aggregated damages, year by year, for each of 10,000 probabilistic socioeconomic-climate parameter draws.
+The damage functions were estimated by the Climate Impact Lab (CIL) using the Data-driven Spatial Climate Impact Model (DSCIM). The underlying model computes sector-specific climate damages at roughly 24,000 impact regions worldwide, then aggregates them to the global (or national) level. The coefficients provided here are the result of fitting quadratic regression functions to those aggregated damages, year by year for each socioeconomics pathway**. (**Note, damage functions are initially estimated on damages based on Shared Socioeconomic Pathways, or SSPs. Those damage functions are then used to emulate damage functions for Resources for the Future Socioeconomic Pathways, or RFF-SPs, provided here).
 
 For methodological details, see [References](#references).
 
@@ -14,8 +14,8 @@ After running `directory_setup.py` (or downloading and unzipping the input data)
 ```
 damage_functions/
 |-- damage_function_weights.nc4       # Emulator weights
-|-- CAMEL_m1_c0.20/                   # Combined sector, global
-|-- CAMEL_m1_c0.20_USA/               # Combined sector, USA
+|-- CAMEL_m1_c0.20/                   # Combined sectors, global
+|-- CAMEL_m1_c0.20_USA/               # Combined sectors, USA
 |-- agriculture/                      # Agriculture, global
 |-- agriculture_USA/                  # Agriculture, USA
 |-- coastal_v0.20/                    # Coastal, global
@@ -28,7 +28,7 @@ damage_functions/
 |-- mortality_v1_USA/                 # Mortality, USA
 ```
 
-Each sector directory contains NetCDF4 files with damage function coefficients for different combinations of valuation recipe and Ramsey discount rate parameters.
+Each sector directory contains NetCDF4 files with damage function coefficients for different combinations of valuation recipe and `eta` (elasticity of marginal utility of consumption) parameters.
 
 
 ## Sectors
@@ -42,14 +42,13 @@ Each sector directory contains NetCDF4 files with damage function coefficients f
 | `mortality_v1`     | Mortality damages (version 1) |
 | `CAMEL_m1_c0.20`   | **Combined**: all five sectors above, aggregated |
 
-**CAMEL** stands for Coastal, Agriculture, Mortality, Energy, and Labor. The suffix `m1_c0.20` indicates mortality version 1 and coastal version 0.20. Mortality v1 uses VSL (Value of Statistical Life) valuation with ISO-level deaths and impact-region-level costs, and is the EPA main specification. Coastal v0.20 is the original EPA specification using FACTS-based sea level projections (Kopp et al. 2023). CAMEL is the combined multi-sector damage function and is the primary output for computing aggregate SC-GHGs.
-
-There is also an intermediate aggregate, **AMEL** (Agriculture, Mortality, Energy, Labor, i.e. CAMEL without the coastal component), which appears in the codebase configuration but does not have pre-computed coefficient files.
+**CAMEL** stands for Coastal, Agriculture, Mortality, Energy, and Labor. The suffix `m1_c0.20` indicates mortality version 1 and coastal version 0.20. Mortality v1 uses VSL (Value of Statistical Life) valuation with ISO-level VSL applied to deaths and impact-region-level VSL applied to adaptation costs, and is the EPA main specification. Coastal v0.20 is the original EPA specification using FACTS-based sea level projections (Kopp et al. 2023). CAMEL is the combined multi-sector damage function and is the primary output for computing aggregate SC-GHGs.
 
 Each sector has a `_USA` variant containing coefficients for damages restricted to the United States, used for computing territorial U.S. SC-GHGs.
 
-
 ## File naming convention
+
+> Note: the damage function coefficient filenames have many quirks that can be confusing, so we aim to be transparent about those here. The quirks are a function of the way settings are handled and filenames are set up in the `dscim` library. We are planning to improve output names among other things in a future release.
 
 Files follow this pattern:
 
@@ -60,29 +59,11 @@ Files follow this pattern:
 Where:
 
 - **recipe**: The valuation approach. Either `risk_aversion` or `adding_up`.
-  - `risk_aversion`: Certainty-equivalent damages accounting for risk aversion across climate and socioeconomic uncertainty. This is the primary recipe used in the EPA specification.
-  - `adding_up`: A simpler approach that sums damages across regions without certainty-equivalent adjustments. Only available for the CAMEL sector.
-- **euler_ramsey**: The discounting framework (Euler equation with Ramsey discounting). All files use this framework.
-- **eta**: Elasticity of marginal utility of consumption (the concavity of the CRRA utility function).
-- **rho**: Pure rate of time preference.
-
-### Available parameter combinations
-
-| Near-term discount rate | eta     | rho     |
-|------------------------|---------|---------|
-| 1.5% Ramsey            | 1.016   | 0.0     |
-| 2.0% Ramsey            | 1.244   | 0.002   |
-| 2.5% Ramsey            | 1.421   | 0.005   |
-| 3.0% Ramsey            | 1.568   | 0.008   |
-
-These four (eta, rho) pairs correspond to the near-term certainty-equivalent discount rates described in the EPA technical report. The label (e.g. "2.0% Ramsey") is approximate and used for identification only. The actual discount rate varies over time because it is computed from the realized consumption growth rate of each draw, following stochastic Ramsey discounting (Section 5.1 of the DSCIM User Manual, eq. 11):
-
-```
-SDF_ky = product over tau from u to y of exp( -(rho + eta * g_c_k_tau) )
-```
-
-where `g_c_k_tau = ln(c_k_tau / c_k_tau-1)` is the consumption growth rate of draw `k` in year `tau`, and `c_k_tau` is global GDP minus climate damages in that draw and year.
-
+  - `risk_aversion`: Indicates the damage functions were fit on certainty-equivalent damages accounting for uncertainty in the underlying statistical relationships between impact region damages and weather. This is the primary recipe used in the EPA specification.
+  - `adding_up`: Indicates the damage functions were fit on mean, not certainty equivalent, damages. This is also known as "risk neutral". Only available for the CAMEL sector.
+- **euler_ramsey**: Discount method. **This can be ignored** - damage functions do not vary by discount type. 
+- **eta**: Elasticity of marginal utility of consumption (the concavity of the CRRA utility function) used in the certainty-equivalent calculation. This setting is **only applicable to `risk_aversion` damage functions**. Although there exists an `adding_up` file for each `eta` in the directory, they are exactly the same.
+- **rho**: Pure rate of time preference. **This can be ignored** - damage functions do not vary by `rho`. 
 
 ## Data structure of coefficient files
 
@@ -92,7 +73,7 @@ Each `.nc4` file is a NetCDF4 dataset with the following structure:
 
 | Dimension        | Size   | Description |
 |-----------------|--------|-------------|
-| `discount_type` | 1      | Discounting framework (always `"euler_ramsey"`) |
+| `discount_type` | 1      | Discounting framework (always `"euler_ramsey"`) **Should be ignored** |
 | `year`          | 281    | Year of the damage function, from 2020 to 2300 |
 | `runid`         | 10,000 | RFF socioeconomic pathway draw index (1 to 10,000) |
 
@@ -128,19 +109,13 @@ The data variables are the **regression coefficients** (betas) of the damage fun
 
 ## Formulas
 
-The damage functions are quadratic regressions (without intercept) of global damages on climate variables. For each sector, year, and SSP-growth model combination, the damage function is estimated by OLS across the 33 GCMs and 2 RCP emissions scenarios (Section 4.2 of the DSCIM User Manual, eq. 4):
-
-```
-damages_slpyj = beta1_syj * dGMST_ylp + beta2_syj * dGMST_ylp^2 + error
-```
-
-where `l` indexes the climate model, `p` the emissions scenario, `y` the year, `j` the SSP-growth model, and `dGMST` is the temperature anomaly relative to the 2001-2010 average. An analogous equation is estimated for the coastal sector with `dGMSL` in place of `dGMST`. These SSP-based damage functions are then emulated for each of the 10,000 RFF-SP draws (see Appendix B of the User Manual), producing the coefficients stored in these files.
+The damage functions are quadratic regressions (without intercept) of global damages on climate variables. For each sector, year, and SSP-growth model combination, the damage function is estimated by ordinary least-squares regression across the 33 GCMs and 2 RCP emissions scenarios (Section 4.2 of the DSCIM User Manual). These SSP-based damage functions are then used to emulate damage functions for each of the 10,000 RFF-SP draws (see Appendix B of the User Manual), producing the coefficients stored in these files.
 
 The regression specification for each sector type is:
 
 **Temperature-driven sectors:**
 ```
-damages = beta_anomaly * T + beta_anomaly2 * T^2
+damages = beta_gmst * T + beta_gmst2 * T^2
 ```
 
 **Coastal sector:**
@@ -150,12 +125,12 @@ damages = beta_gmsl * S + beta_gmsl2 * S^2
 
 **CAMEL (combined):**
 ```
-damages = beta_anomaly * T + beta_anomaly2 * T^2 + beta_gmsl * S + beta_gmsl2 * S^2
+damages = beta_gmst * T + beta_gmst2 * T^2 + beta_gmsl * S + beta_gmsl2 * S^2
 ```
 
 Where:
 - `T` is the global mean surface temperature (GMST) anomaly
-- `S` is global mean sea level (GMSL)
+- `S` is global mean sea level (GMSL) anomaly
 - The beta coefficients are the variables stored in the `.nc4` files
 
 The formulas have no intercept, meaning that zero climate change implies zero damages.
@@ -167,8 +142,8 @@ The formulas have no intercept, meaning that zero climate change implies zero da
 
 The coefficient files contain no embedded unit metadata. The units are inferred from the DSCIM codebase and preprocessing pipeline:
 
-- The damage function coefficients produce **damages in 2019 PPP-adjusted USD** when multiplied by the climate variables described below. This is confirmed by the DSCIM preprocessing code, which converts underlying RFF-SP GDP data from 2011 USD to 2019 USD using a GDP deflator before estimating the damage functions (see `dscim/utils/rff.py` and `dscim/preprocessing/input_damages.py` in the `dscim` package).
-- In the SC-GHG calculation pipeline (`scripts/scghg_utils.py`), the final output is further deflated from 2019 to **2020 USD** using the factor `113.648 / 112.29`. This deflator is applied after the damage functions are evaluated, not within the coefficient files.
+- The damage function coefficients produce **damages in 2019 PPP-adjusted USD** when multiplied by the climate variables described below. 
+- The final SC-GHG output is converted from 2019 to **2020 USD** using the factor `113.648 / 112.29`. This deflator is applied after the damage functions are evaluated, not within the coefficient files.
 
 The coefficients thus have the following effective units:
 
@@ -181,29 +156,15 @@ The coefficients thus have the following effective units:
 
 where USD refers to 2019 PPP-adjusted U.S. dollars, and the resulting damages are in total (global or USA) dollars, not per capita.
 
-### Climate variable baselines
+### Required climate variable baselines
 
-**GMST anomaly (T):** Celsius, relative to the **2001-2010 mean**. The DSCIM pipeline rebases FaIR temperature output (originally relative to 1765) to this base period. The rebasing is done per simulation: for each of the 10,000 draws, the mean temperature over 2001-2010 is subtracted from the full time series. The relevant code is in `Climate.gmst_anomalies` in [`dscim/menu/simple_storage.py` (v0.5.0)](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py):
+**GMST anomaly (T):** Celsius, relative to the **2001-2010 mean**. The DSCIM pipeline rebases FaIR temperature output to this base period. If you are bringing your own temperature trajectory, you need to subtract the mean of the trajectory over 2001-2010 before applying the coefficients.
 
-```python
-base_period = temps.sel(
-    year=slice(self.base_period[0], self.base_period[1])
-).mean(dim="year")
-anomaly = temps - base_period
-```
+**GMSL (S):** Centimeters, relative to the **1991-2009 mean**. No rebasing is applied in the pipeline because coastal damages are estimated relative to the same period. If you are bringing your own sea level trajectory, you need to subtract the mean of the trajectory over 1991-2009 before applying the coefficients.
 
-where `base_period` defaults to `(2001, 2010)`. If you are bringing your own temperature trajectory (for example from DICE), you need to subtract the mean of your control trajectory over 2001-2010 before applying the coefficients.
+> *Note: FACTS outputs are in millimeters and are converted to centimeters by dividing by 10 before being stored in these files.*
 
-**GMSL (S):** Centimeters, relative to the **1991-2009 mean**. No rebasing is applied in the pipeline because coastal damages are estimated relative to the same period.
-
-> *Note: FACTS outputs are in millimeters and are converted to centimeters by dividing by 10 before being stored in these files. See `Climate.gmsl_anomalies` in [`simple_storage.py`](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py).*
-
-### Spatial aggregation
-
-The coefficients are **globally aggregated** (or USA-aggregated for the `_USA` variants). They do not contain a region dimension. The underlying DSCIM model estimates damages at roughly 24,000 impact regions worldwide, but these coefficients are the result of fitting damage functions to the aggregated output. A researcher using these files works with the relationship between global climate variables and total global damages, not with spatially disaggregated impact estimates.
-
-
-## Loading the data
+## Loading and applying the coefficients
 
 The files can be opened with any NetCDF-compatible library. Using Python and xarray:
 
@@ -217,75 +178,34 @@ ds = xr.open_dataset(
 )
 
 # Access coefficients for a specific year and draw
-beta_T = ds["anomaly"].sel(year=2050, runid=1).values       # linear GMST coefficient
-beta_T2 = ds["np.power(anomaly, 2)"].sel(year=2050, runid=1).values  # quadratic GMST
-beta_S = ds["gmsl"].sel(year=2050, runid=1).values           # linear GMSL coefficient
-beta_S2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values    # quadratic GMSL
+beta_gmst = ds["anomaly"].sel(year=2050, runid=1).values       # linear GMST coefficient
+beta_gmst2 = ds["np.power(anomaly, 2)"].sel(year=2050, runid=1).values  # quadratic GMST
+beta_gmsl = ds["gmsl"].sel(year=2050, runid=1).values           # linear GMSL coefficient
+beta_gmsl2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values    # quadratic GMSL
 
 # Compute damages given climate inputs
 T = 2.0   # GMST anomaly in Celsius relative to 2001-2010
 S = 30.0  # GMSL in cm relative to 1991-2009
-damages = beta_T * T + beta_T2 * T**2 + beta_S * S + beta_S2 * S**2
+damages = beta_gmst * T + beta_gmst2 * T**2 + beta_gmsl * S + beta_gmsl2 * S**2
 # Result is in 2019 PPP-adjusted USD (total global damages)
 ```
 
 
-## Using the damage functions in other models
+## Using the damage functions
 
-Researchers wishing to integrate these damage functions into DICE or another integrated assessment model should note the following:
+Researchers wishing to use these damage functions should note the following:
 
-1. **Climate variable conventions**: Ensure that your model's temperature and sea level variables use the same baselines (GMST relative to 2001-2010; GMSL relative to 1991-2009) and units (Celsius; centimeters). Rebasing may be required.
+1. **Climate variable conventions**: Ensure that your model's temperature and sea level variables use the same baselines (GMST relative to 2001-2010; GMSL relative to 1991-2009) and units (Celsius; centimeters).
 
 2. **Temporal resolution**: Coefficients are provided annually from 2020 to 2300. Each year has its own set of coefficients; the damage function is not time-invariant. This reflects the fact that the relationship between climate variables and damages evolves as the economy grows and adapts.
 
-3. **Probabilistic draws**: The 10,000 `runid` draws represent joint uncertainty in socioeconomic pathways and climate parameters. For a deterministic IAM run, one option is to use the mean (or median) across draws for each year. For uncertainty analysis, the draws can be sampled or used in a Monte Carlo framework.
+3. **Probabilistic draws**: Coefficients are provided for each of 10,000 `runid` draws, which represent joint uncertainty in socioeconomic pathways and climate parameters. 
 
-4. **Sector choice**: For aggregate SC-GHG calculations, use the CAMEL files (combined sector). Individual sector files are useful for understanding the sectoral composition of damages but should not be summed, as the CAMEL coefficients already represent the combined result.
+4. **Sector choice**: For aggregate SC-GHG calculations, use the CAMEL files ("combined" sector). Individual sector files are useful for understanding the sectoral composition of damages but should not be summed, as the CAMEL coefficients already represent the combined result.
 
-5. **Recipe choice**: The `risk_aversion` recipe is the primary specification used in the EPA analysis. The `adding_up` recipe is a simpler alternative available only for CAMEL. The two recipes differ in how local damages are aggregated. In `adding_up` (risk-neutral), damages across dose-response function draws are averaged within each impact region before summing globally. In `risk_aversion`, a certainty equivalent (CE) is computed within each of the 24,378 impact regions using a CRRA utility function with elasticity eta:
+5. **Recipe choice**: The `risk_aversion` recipe is the primary specification used in the EPA specification. The `adding_up` recipe is a "risk neutral" alternative available only for CAMEL. The two recipes differ in how local damages are aggregated. In `adding_up` (risk-neutral), damages across dose-response function draws are averaged within each impact region before summing globally and fitting the damage function. In `risk_aversion`, a certainty equivalent (CE) is computed within each of the 24,378 impact regions using a CRRA utility function with elasticity `eta`, before summing globally and fitting the damage function. Risk-averse damages are typically larger than the risk-neutral mean because they include a premium for severe outcomes. See Section 4.1.2 and Appendix A of the DSCIM User Manual (September 2023) for the full derivation.
 
-    ```
-    CE_cc = [ (1/K) * sum_d( C_d^(1-eta) / (1-eta) ) * (1-eta) ]^(1/(1-eta))
-    ```
-
-    where `C_d = GDPpc - damages_d` is per capita consumption in draw `d`. The difference between the CE under no-climate-change and the CE under climate change gives risk-averse damages, which are larger than the risk-neutral mean because they include a premium for severe outcomes. See Section 4.1.2 and Appendix A of the DSCIM User Manual (September 2022) for the full derivation.
-
-6. **Currency conversion**: The coefficients produce damages in 2019 PPP-adjusted USD. Apply a deflator if your model uses a different base year. The DSCIM-FACTS-EPA pipeline uses `113.648 / 112.29` to convert from 2019 to 2020 USD. This deflator is applied after evaluating the damage function, not within the coefficient files.
-
-7. **Marginal damages and SC-GHG**: To compute the SC-GHG, evaluate the damage function under both a control (no-pulse) and pulse climate trajectory, take the difference (marginal damages), discount the stream, and sum. A minimal example:
-
-    ```python
-    import xarray as xr
-
-    ds = xr.open_dataset(
-        "input/damage_functions/CAMEL_m1_c0.20/"
-        "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
-    ).squeeze("discount_type", drop=True)
-
-    def eval_damages(T, S, ds):
-        b1 = ds["anomaly"]
-        b2 = ds["np.power(anomaly, 2)"]
-        b3 = ds["gmsl"]
-        b4 = ds["np.power(gmsl, 2)"]
-        return b1 * T + b2 * T**2 + b3 * S + b4 * S**2
-
-    # T_control, T_pulse: xr.DataArray with dims (runid, year)
-    # S_control, S_pulse: same, in cm relative to 1991-2009
-    # T arrays must be rebased to the 2001-2010 mean of the control
-
-    damages_control = eval_damages(T_control, S_control, ds)
-    damages_pulse   = eval_damages(T_pulse,   S_pulse,   ds)
-    marginal_damages = damages_pulse - damages_control
-
-    # Mean across draws for a deterministic estimate
-    marginal_damages_mean = marginal_damages.mean("runid")
-
-    # Convert to 2020 USD
-    marginal_damages_2020usd = marginal_damages_mean * (113.648 / 112.29)
-    ```
-
-    The gas-specific pulse conversion factors are defined in the run configuration (see `gas_conversions` in the generated config file). The default CO2 pulse conversion is `2.72916487e-10`, which converts a 1 GtC pulse to per-tonne-CO2 units.
-
+6. **Currency units**: The coefficients produce damages in 2019 PPP-adjusted USD. The DSCIM-FACTS-EPA pipeline uses `113.648 / 112.29` to convert the calculated SC-GHGs from 2019 to 2020 USD.
 
 ## References
 
@@ -299,7 +219,7 @@ Researchers wishing to integrate these damage functions into DICE or another int
 
 - Resources for the Future (2022). RFF Socioeconomic Projections (RFF-SPv2). https://www.rff.org/publications/data-tools/
 
-- Climate Impact Lab. DSCIM: The Data-driven Spatial Climate Impact Model. https://impactlab.org/
+- Climate Impact Lab. DSCIM: The Data-driven Spatial Climate Impact Model. https://impactlab.org/research/data-driven-spatial-climate-impact-model-user-manual-version-092023-epa/
 
 - Smith, C. J., et al. (2018). FAIR v1.3: A simple emissions-based impulse response and carbon cycle model. *Geoscientific Model Development*, 11(6), 2273-2297.
 

--- a/DAMAGE_FUNCTIONS.md
+++ b/DAMAGE_FUNCTIONS.md
@@ -170,6 +170,7 @@ The files can be opened with any NetCDF-compatible library. Using Python and xar
 
 ```python
 import xarray as xr
+import numpy as np
 
 # Load CAMEL risk-aversion coefficients for the 2.0% Ramsey discount rate
 ds = xr.open_dataset(
@@ -186,7 +187,7 @@ beta_gmsl2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values    # quadrat
 # Compute damages given climate inputs
 T = 2.0   # GMST anomaly in Celsius relative to 2001-2010
 S = 30.0  # GMSL in cm relative to 1991-2009
-damages = beta_gmst * T + beta_gmst2 * T**2 + beta_gmsl * S + beta_gmsl2 * S**2
+damages = beta_gmst * T + beta_gmst2 * np.power(T, 2) + beta_gmsl * S + beta_gmsl2 * np.power(S, 2)
 # Result is in 2019 PPP-adjusted USD (total global damages)
 ```
 

--- a/DAMAGE_FUNCTIONS.md
+++ b/DAMAGE_FUNCTIONS.md
@@ -1,0 +1,306 @@
+# Damage Functions
+
+This document provides detailed documentation for the pre-computed damage function coefficients distributed with DSCIM-FACTS-EPA. These coefficients are the core input for translating climate projections (global mean surface temperature and global mean sea level) into monetized climate damages used to compute the Social Cost of Greenhouse Gases (SC-GHG).
+
+The damage functions were estimated by the Climate Impact Lab (CIL) using the Data-driven Spatial Climate Impact Model (DSCIM). The underlying model computes sector-specific climate damages at roughly 24,000 impact regions worldwide, then aggregates them to the global (or national) level. The coefficients provided here are the result of fitting quadratic regression functions to those globally aggregated damages, year by year, for each of 10,000 probabilistic socioeconomic-climate parameter draws.
+
+For methodological details, see [References](#references).
+
+
+## Directory structure
+
+After running `directory_setup.py` (or downloading and unzipping the input data), the damage function files are located in `input/damage_functions/`:
+
+```
+damage_functions/
+|-- damage_function_weights.nc4       # Emulator weights
+|-- CAMEL_m1_c0.20/                   # Combined sector, global
+|-- CAMEL_m1_c0.20_USA/               # Combined sector, USA
+|-- agriculture/                      # Agriculture, global
+|-- agriculture_USA/                  # Agriculture, USA
+|-- coastal_v0.20/                    # Coastal, global
+|-- coastal_v0.20_USA/                # Coastal, USA
+|-- energy/                           # Energy, global
+|-- energy_USA/                       # Energy, USA
+|-- labor/                            # Labor, global
+|-- labor_USA/                        # Labor, USA
+|-- mortality_v1/                     # Mortality, global
+|-- mortality_v1_USA/                 # Mortality, USA
+```
+
+Each sector directory contains NetCDF4 files with damage function coefficients for different combinations of valuation recipe and Ramsey discount rate parameters.
+
+
+## Sectors
+
+| Directory name     | Description |
+|--------------------|-------------|
+| `agriculture`      | Agricultural productivity damages |
+| `coastal_v0.20`    | Coastal damages from sea level rise (version 0.20) |
+| `energy`           | Energy expenditure damages (heating and cooling) |
+| `labor`            | Labor productivity damages |
+| `mortality_v1`     | Mortality damages (version 1) |
+| `CAMEL_m1_c0.20`   | **Combined**: all five sectors above, aggregated |
+
+**CAMEL** stands for Coastal, Agriculture, Mortality, Energy, and Labor. The suffix `m1_c0.20` indicates mortality version 1 and coastal version 0.20. Mortality v1 uses VSL (Value of Statistical Life) valuation with ISO-level deaths and impact-region-level costs, and is the EPA main specification. Coastal v0.20 is the original EPA specification using FACTS-based sea level projections (Kopp et al. 2023). CAMEL is the combined multi-sector damage function and is the primary output for computing aggregate SC-GHGs.
+
+There is also an intermediate aggregate, **AMEL** (Agriculture, Mortality, Energy, Labor, i.e. CAMEL without the coastal component), which appears in the codebase configuration but does not have pre-computed coefficient files.
+
+Each sector has a `_USA` variant containing coefficients for damages restricted to the United States, used for computing territorial U.S. SC-GHGs.
+
+
+## File naming convention
+
+Files follow this pattern:
+
+```
+{recipe}_euler_ramsey_eta{eta}_rho{rho}_dfc.nc4
+```
+
+Where:
+
+- **recipe**: The valuation approach. Either `risk_aversion` or `adding_up`.
+  - `risk_aversion`: Certainty-equivalent damages accounting for risk aversion across climate and socioeconomic uncertainty. This is the primary recipe used in the EPA specification.
+  - `adding_up`: A simpler approach that sums damages across regions without certainty-equivalent adjustments. Only available for the CAMEL sector.
+- **euler_ramsey**: The discounting framework (Euler equation with Ramsey discounting). All files use this framework.
+- **eta**: Elasticity of marginal utility of consumption (the concavity of the CRRA utility function).
+- **rho**: Pure rate of time preference.
+
+### Available parameter combinations
+
+| Near-term discount rate | eta     | rho     |
+|------------------------|---------|---------|
+| 1.5% Ramsey            | 1.016   | 0.0     |
+| 2.0% Ramsey            | 1.244   | 0.002   |
+| 2.5% Ramsey            | 1.421   | 0.005   |
+| 3.0% Ramsey            | 1.568   | 0.008   |
+
+These four (eta, rho) pairs correspond to the near-term certainty-equivalent discount rates described in the EPA technical report. The label (e.g. "2.0% Ramsey") is approximate and used for identification only. The actual discount rate varies over time because it is computed from the realized consumption growth rate of each draw, following stochastic Ramsey discounting (Section 5.1 of the DSCIM User Manual, eq. 11):
+
+```
+SDF_ky = product over tau from u to y of exp( -(rho + eta * g_c_k_tau) )
+```
+
+where `g_c_k_tau = ln(c_k_tau / c_k_tau-1)` is the consumption growth rate of draw `k` in year `tau`, and `c_k_tau` is global GDP minus climate damages in that draw and year.
+
+
+## Data structure of coefficient files
+
+Each `.nc4` file is a NetCDF4 dataset with the following structure:
+
+### Dimensions
+
+| Dimension        | Size   | Description |
+|-----------------|--------|-------------|
+| `discount_type` | 1      | Discounting framework (always `"euler_ramsey"`) |
+| `year`          | 281    | Year of the damage function, from 2020 to 2300 |
+| `runid`         | 10,000 | RFF socioeconomic pathway draw index (1 to 10,000) |
+
+Each `runid` corresponds to one draw from the joint distribution of socioeconomic projections (from the Resources for the Future Socioeconomic Pathways, RFF-SPv2) and climate model parameters (from FaIR). The mapping between `runid` and underlying scenario parameters is documented in the EPA technical report.
+
+### Variables
+
+The data variables are the **regression coefficients** (betas) of the damage function. Their names correspond to the terms in the regression formula. The variables present depend on the sector:
+
+**Temperature-driven sectors** (agriculture, energy, labor, mortality):
+
+| Variable               | Description |
+|------------------------|-------------|
+| `anomaly`              | Coefficient on the linear GMST anomaly term |
+| `np.power(anomaly, 2)` | Coefficient on the squared GMST anomaly term |
+
+**Coastal sector** (coastal_v0.20):
+
+| Variable               | Description |
+|------------------------|-------------|
+| `gmsl`                 | Coefficient on the linear GMSL term |
+| `np.power(gmsl, 2)`    | Coefficient on the squared GMSL term |
+
+**Combined sector** (CAMEL_m1_c0.20):
+
+| Variable               | Description |
+|------------------------|-------------|
+| `anomaly`              | Coefficient on the linear GMST anomaly term |
+| `np.power(anomaly, 2)` | Coefficient on the squared GMST anomaly term |
+| `gmsl`                 | Coefficient on the linear GMSL term |
+| `np.power(gmsl, 2)`    | Coefficient on the squared GMSL term |
+
+
+## Formulas
+
+The damage functions are quadratic regressions (without intercept) of global damages on climate variables. For each sector, year, and SSP-growth model combination, the damage function is estimated by OLS across the 33 GCMs and 2 RCP emissions scenarios (Section 4.2 of the DSCIM User Manual, eq. 4):
+
+```
+damages_slpyj = beta1_syj * dGMST_ylp + beta2_syj * dGMST_ylp^2 + error
+```
+
+where `l` indexes the climate model, `p` the emissions scenario, `y` the year, `j` the SSP-growth model, and `dGMST` is the temperature anomaly relative to the 2001-2010 average. An analogous equation is estimated for the coastal sector with `dGMSL` in place of `dGMST`. These SSP-based damage functions are then emulated for each of the 10,000 RFF-SP draws (see Appendix B of the User Manual), producing the coefficients stored in these files.
+
+The regression specification for each sector type is:
+
+**Temperature-driven sectors:**
+```
+damages = beta_anomaly * T + beta_anomaly2 * T^2
+```
+
+**Coastal sector:**
+```
+damages = beta_gmsl * S + beta_gmsl2 * S^2
+```
+
+**CAMEL (combined):**
+```
+damages = beta_anomaly * T + beta_anomaly2 * T^2 + beta_gmsl * S + beta_gmsl2 * S^2
+```
+
+Where:
+- `T` is the global mean surface temperature (GMST) anomaly
+- `S` is global mean sea level (GMSL)
+- The beta coefficients are the variables stored in the `.nc4` files
+
+The formulas have no intercept, meaning that zero climate change implies zero damages.
+
+
+## Units and baselines
+
+### Units of the coefficients
+
+The coefficient files contain no embedded unit metadata. The units are inferred from the DSCIM codebase and preprocessing pipeline:
+
+- The damage function coefficients produce **damages in 2019 PPP-adjusted USD** when multiplied by the climate variables described below. This is confirmed by the DSCIM preprocessing code, which converts underlying RFF-SP GDP data from 2011 USD to 2019 USD using a GDP deflator before estimating the damage functions (see `dscim/utils/rff.py` and `dscim/preprocessing/input_damages.py` in the `dscim` package).
+- In the SC-GHG calculation pipeline (`scripts/scghg_utils.py`), the final output is further deflated from 2019 to **2020 USD** using the factor `113.648 / 112.29`. This deflator is applied after the damage functions are evaluated, not within the coefficient files.
+
+The coefficients thus have the following effective units:
+
+| Variable               | Units |
+|------------------------|-------|
+| `anomaly`              | USD / Celsius |
+| `np.power(anomaly, 2)` | USD / Celsius^2 |
+| `gmsl`                 | USD / cm |
+| `np.power(gmsl, 2)`    | USD / cm^2 |
+
+where USD refers to 2019 PPP-adjusted U.S. dollars, and the resulting damages are in total (global or USA) dollars, not per capita.
+
+### Climate variable baselines
+
+**GMST anomaly (T):** Celsius, relative to the **2001-2010 mean**. The DSCIM pipeline rebases FaIR temperature output (originally relative to 1765) to this base period. The rebasing is done per simulation: for each of the 10,000 draws, the mean temperature over 2001-2010 is subtracted from the full time series. The relevant code is in `Climate.gmst_anomalies` in [`dscim/menu/simple_storage.py` (v0.5.0)](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py):
+
+```python
+base_period = temps.sel(
+    year=slice(self.base_period[0], self.base_period[1])
+).mean(dim="year")
+anomaly = temps - base_period
+```
+
+where `base_period` defaults to `(2001, 2010)`. If you are bringing your own temperature trajectory (for example from DICE), you need to subtract the mean of your control trajectory over 2001-2010 before applying the coefficients.
+
+**GMSL (S):** Centimeters, relative to the **1991-2009 mean**. No rebasing is applied in the pipeline because coastal damages are estimated relative to the same period.
+
+> *Note: FACTS outputs are in millimeters and are converted to centimeters by dividing by 10 before being stored in these files. See `Climate.gmsl_anomalies` in [`simple_storage.py`](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py).*
+
+### Spatial aggregation
+
+The coefficients are **globally aggregated** (or USA-aggregated for the `_USA` variants). They do not contain a region dimension. The underlying DSCIM model estimates damages at roughly 24,000 impact regions worldwide, but these coefficients are the result of fitting damage functions to the aggregated output. A researcher using these files works with the relationship between global climate variables and total global damages, not with spatially disaggregated impact estimates.
+
+
+## Loading the data
+
+The files can be opened with any NetCDF-compatible library. Using Python and xarray:
+
+```python
+import xarray as xr
+
+# Load CAMEL risk-aversion coefficients for the 2.0% Ramsey discount rate
+ds = xr.open_dataset(
+    "input/damage_functions/CAMEL_m1_c0.20/"
+    "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
+)
+
+# Access coefficients for a specific year and draw
+beta_T = ds["anomaly"].sel(year=2050, runid=1).values       # linear GMST coefficient
+beta_T2 = ds["np.power(anomaly, 2)"].sel(year=2050, runid=1).values  # quadratic GMST
+beta_S = ds["gmsl"].sel(year=2050, runid=1).values           # linear GMSL coefficient
+beta_S2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values    # quadratic GMSL
+
+# Compute damages given climate inputs
+T = 2.0   # GMST anomaly in Celsius relative to 2001-2010
+S = 30.0  # GMSL in cm relative to 1991-2009
+damages = beta_T * T + beta_T2 * T**2 + beta_S * S + beta_S2 * S**2
+# Result is in 2019 PPP-adjusted USD (total global damages)
+```
+
+
+## Using the damage functions in other models
+
+Researchers wishing to integrate these damage functions into DICE or another integrated assessment model should note the following:
+
+1. **Climate variable conventions**: Ensure that your model's temperature and sea level variables use the same baselines (GMST relative to 2001-2010; GMSL relative to 1991-2009) and units (Celsius; centimeters). Rebasing may be required.
+
+2. **Temporal resolution**: Coefficients are provided annually from 2020 to 2300. Each year has its own set of coefficients; the damage function is not time-invariant. This reflects the fact that the relationship between climate variables and damages evolves as the economy grows and adapts.
+
+3. **Probabilistic draws**: The 10,000 `runid` draws represent joint uncertainty in socioeconomic pathways and climate parameters. For a deterministic IAM run, one option is to use the mean (or median) across draws for each year. For uncertainty analysis, the draws can be sampled or used in a Monte Carlo framework.
+
+4. **Sector choice**: For aggregate SC-GHG calculations, use the CAMEL files (combined sector). Individual sector files are useful for understanding the sectoral composition of damages but should not be summed, as the CAMEL coefficients already represent the combined result.
+
+5. **Recipe choice**: The `risk_aversion` recipe is the primary specification used in the EPA analysis. The `adding_up` recipe is a simpler alternative available only for CAMEL. The two recipes differ in how local damages are aggregated. In `adding_up` (risk-neutral), damages across dose-response function draws are averaged within each impact region before summing globally. In `risk_aversion`, a certainty equivalent (CE) is computed within each of the 24,378 impact regions using a CRRA utility function with elasticity eta:
+
+    ```
+    CE_cc = [ (1/K) * sum_d( C_d^(1-eta) / (1-eta) ) * (1-eta) ]^(1/(1-eta))
+    ```
+
+    where `C_d = GDPpc - damages_d` is per capita consumption in draw `d`. The difference between the CE under no-climate-change and the CE under climate change gives risk-averse damages, which are larger than the risk-neutral mean because they include a premium for severe outcomes. See Section 4.1.2 and Appendix A of the DSCIM User Manual (September 2022) for the full derivation.
+
+6. **Currency conversion**: The coefficients produce damages in 2019 PPP-adjusted USD. Apply a deflator if your model uses a different base year. The DSCIM-FACTS-EPA pipeline uses `113.648 / 112.29` to convert from 2019 to 2020 USD. This deflator is applied after evaluating the damage function, not within the coefficient files.
+
+7. **Marginal damages and SC-GHG**: To compute the SC-GHG, evaluate the damage function under both a control (no-pulse) and pulse climate trajectory, take the difference (marginal damages), discount the stream, and sum. A minimal example:
+
+    ```python
+    import xarray as xr
+
+    ds = xr.open_dataset(
+        "input/damage_functions/CAMEL_m1_c0.20/"
+        "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
+    ).squeeze("discount_type", drop=True)
+
+    def eval_damages(T, S, ds):
+        b1 = ds["anomaly"]
+        b2 = ds["np.power(anomaly, 2)"]
+        b3 = ds["gmsl"]
+        b4 = ds["np.power(gmsl, 2)"]
+        return b1 * T + b2 * T**2 + b3 * S + b4 * S**2
+
+    # T_control, T_pulse: xr.DataArray with dims (runid, year)
+    # S_control, S_pulse: same, in cm relative to 1991-2009
+    # T arrays must be rebased to the 2001-2010 mean of the control
+
+    damages_control = eval_damages(T_control, S_control, ds)
+    damages_pulse   = eval_damages(T_pulse,   S_pulse,   ds)
+    marginal_damages = damages_pulse - damages_control
+
+    # Mean across draws for a deterministic estimate
+    marginal_damages_mean = marginal_damages.mean("runid")
+
+    # Convert to 2020 USD
+    marginal_damages_2020usd = marginal_damages_mean * (113.648 / 112.29)
+    ```
+
+    The gas-specific pulse conversion factors are defined in the run configuration (see `gas_conversions` in the generated config file). The default CO2 pulse conversion is `2.72916487e-10`, which converts a 1 GtC pulse to per-tonne-CO2 units.
+
+
+## References
+
+- U.S. Environmental Protection Agency (2022). *EPA Report on the Social Cost of Greenhouse Gases: Estimates Incorporating Recent Scientific Advances*. External Review Draft. EPA-HQ-OAR-2021-0317. Available at: https://www.epa.gov/environmental-economics/scghg
+
+- Carleton, T., et al. (2022). Valuing the Global Mortality Consequences of Climate Change Accounting for Adaptation Costs and Benefits. *The Quarterly Journal of Economics*, 137(4), 2037-2105.
+
+- Rode, A., et al. (2021). Estimating a Social Cost of Carbon for Global Energy Consumption. *Nature*, 598, 308-314.
+
+- Rennert, K., et al. (2022). Comprehensive Evidence Implies a Higher Social Cost of CO2. *Nature*, 610, 687-692.
+
+- Resources for the Future (2022). RFF Socioeconomic Projections (RFF-SPv2). https://www.rff.org/publications/data-tools/
+
+- Climate Impact Lab. DSCIM: The Data-driven Spatial Climate Impact Model. https://impactlab.org/
+
+- Smith, C. J., et al. (2018). FAIR v1.3: A simple emissions-based impulse response and carbon cycle model. *Geoscientific Model Development*, 11(6), 2273-2297.
+
+- Kopp, R. E., et al. (2023). The Framework for Assessing Changes To Sea-level (FACTS). *Earth's Future*, 11, e2023EF003790.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This README is organized as follows:
 - [Further Information](#further-information)
     - [Creating a `dscim-facts-epa` run config](#creating-a-dscim-facts-epa-run-config)
     - [Input files](#input-files)
+- [Damage function coefficients](#damage-function-coefficients)
 
 ## Types of run cases
 
@@ -453,3 +454,305 @@ Econ
 Damage Functions
 - Files containing a set of damage function coefficients for each RFF draw for each economic sector and valuation choice.
 - RFF damage function emulator weights: damage_function_weights.nc4
+
+
+## Damage function coefficients
+
+This section describes the pre-computed damage function coefficients for computing the Social Cost of Greenhouse Gases (SC-GHG) with DSCIM-FACTS-EPA. The coefficients are quadratic regressions of globally-aggregated climate damages on temperature and sea level, estimated year by year across 10,000 probabilistic socioeconomic-climate draws.
+
+For methodological details, see [References](#references).
+
+### Directory structure
+
+```
+damage_functions/
+|
+|-- damage_function_weights.nc4       # Emulator weights (see below)
+|
+|-- CAMEL_m1_c0.20/                   # Combined sector, global
+|-- CAMEL_m1_c0.20_USA/               # Combined sector, USA
+|-- agriculture/                      # Agriculture, global
+|-- agriculture_USA/                  # Agriculture, USA
+|-- coastal_v0.20/                    # Coastal, global
+|-- coastal_v0.20_USA/                # Coastal, USA
+|-- energy/                           # Energy, global
+|-- energy_USA/                       # Energy, USA
+|-- labor/                            # Labor, global
+|-- labor_USA/                        # Labor, USA
+|-- mortality_v1/                     # Mortality, global
+|-- mortality_v1_USA/                 # Mortality, USA
+|-- google_download/                  # (empty placeholder directories)
+```
+
+Each sector directory contains NetCDF4 files with damage function coefficients for different combinations of valuation recipe and Ramsey discount rate parameters.
+
+
+### Sectors
+
+| Directory name     | Description |
+|--------------------|-------------|
+| `agriculture`      | Agricultural productivity damages |
+| `coastal_v0.20`    | Coastal damages from sea level rise (version 0.20) |
+| `energy`           | Energy expenditure damages (heating and cooling) |
+| `labor`            | Labor productivity damages |
+| `mortality_v1`     | Mortality damages (version 1) |
+| `CAMEL_m1_c0.20`   | **Combined**: all five sectors above, aggregated |
+
+**CAMEL** stands for Coastal, Agriculture, Mortality, Energy, and Labor. The suffix `m1_c0.20` indicates mortality version 1 and coastal version 0.20. Mortality v1 uses VSL (Value of Statistical Life) valuation with ISO-level deaths and impact-region-level costs -- this is the EPA main specification. Coastal v0.20 is the original EPA specification using FACTS-based sea level projections (Kopp et al. 2023). CAMEL is the primary output for computing aggregate SC-GHGs.
+
+Each sector has a `_USA` variant containing coefficients for damages restricted to the United States, used for computing territorial U.S. SC-GHGs.
+
+
+### File naming convention
+
+Files follow this pattern:
+
+```
+{recipe}_euler_ramsey_eta{eta}_rho{rho}_dfc.nc4
+```
+
+Where:
+
+- **recipe**: The valuation approach. Either `risk_aversion` or `adding_up`.
+  - `risk_aversion`: Certainty-equivalent damages accounting for risk aversion across climate and socioeconomic uncertainty. This is the primary recipe used in the EPA specification.
+  - `adding_up`: A simpler approach that sums damages across regions without certainty-equivalent adjustments. Only available for the CAMEL sector.
+- **euler_ramsey**: The discounting framework (Euler equation with Ramsey discounting). All files use this framework.
+- **eta**: Elasticity of marginal utility of consumption (the concavity of the CRRA utility function).
+- **rho**: Pure rate of time preference.
+
+#### Available parameter combinations
+
+| Near-term discount rate | eta     | rho     |
+|------------------------|---------|---------|
+| 1.5% Ramsey            | 1.016   | 0.0     |
+| 2.0% Ramsey            | 1.244   | 0.002   |
+| 2.5% Ramsey            | 1.421   | 0.005   |
+| 3.0% Ramsey            | 1.568   | 0.008   |
+
+These four (eta, rho) pairs correspond to the near-term certainty-equivalent discount rates described in the EPA technical report. The label (e.g. "2.0% Ramsey") is approximate and used for identification only. The actual discount rate applied in each draw varies over time because it is computed from the realized consumption growth rate of that draw, following stochastic Ramsey discounting (Section 5.1 of the DSCIM User Manual, eq. 11):
+
+```
+SDF_ky = product over tau from u to y of exp( -(rho + eta * g_c_k_tau) )
+```
+
+where `g_c_k_tau = ln(c_k_tau / c_k_tau-1)` is the consumption growth rate of draw `k` in year `tau`, and `c_k_tau` is global GDP minus climate damages in that draw and year. This is implemented in `scghg_utils.py` via `menu_item_global.uncollapsed_discount_factors`, which uses the draw-specific GDP path net of damages rather than a fixed rate.
+
+
+### Data structure of coefficient files
+
+Each `.nc4` file is a NetCDF4 dataset with the following structure.
+
+#### Dimensions
+
+| Dimension        | Size   | Description |
+|-----------------|--------|-------------|
+| `discount_type` | 1      | Discounting framework (always `"euler_ramsey"`) |
+| `year`          | 281    | Year of the damage function, from 2020 to 2300 |
+| `runid`         | 10,000 | RFF socioeconomic pathway draw index (1 to 10,000) |
+
+Each `runid` corresponds to one draw from the joint distribution of socioeconomic projections (from the Resources for the Future Socioeconomic Pathways, RFF-SPv2) and climate model parameters (from FaIR). The mapping between `runid` and underlying scenario parameters is documented in the EPA technical report.
+
+#### Variables
+
+The data variables are the regression coefficients of the damage function. Their names correspond to the terms in the regression formula.
+
+**Temperature-driven sectors** (agriculture, energy, labor, mortality):
+
+| Variable               | Description |
+|------------------------|-------------|
+| `anomaly`              | Coefficient on the linear GMST anomaly term |
+| `np.power(anomaly, 2)` | Coefficient on the squared GMST anomaly term |
+
+**Coastal sector** (coastal_v0.20):
+
+| Variable               | Description |
+|------------------------|-------------|
+| `gmsl`                 | Coefficient on the linear GMSL term |
+| `np.power(gmsl, 2)`    | Coefficient on the squared GMSL term |
+
+**Combined sector** (CAMEL_m1_c0.20):
+
+| Variable               | Description |
+|------------------------|-------------|
+| `anomaly`              | Coefficient on the linear GMST anomaly term |
+| `np.power(anomaly, 2)` | Coefficient on the squared GMST anomaly term |
+| `gmsl`                 | Coefficient on the linear GMSL term |
+| `np.power(gmsl, 2)`    | Coefficient on the squared GMSL term |
+
+
+### Formulas
+
+The damage functions are quadratic regressions (without intercept) of global damages on climate variables. For each sector, year, and SSP-growth model combination, the damage function is estimated by OLS across the 33 GCMs and 2 RCP emissions scenarios (Section 4.2 of the DSCIM User Manual, eq. 4):
+
+```
+damages_slpyj = beta1_syj * dGMST_ylp + beta2_syj * dGMST_ylp^2 + error
+```
+
+where `l` indexes the climate model, `p` the emissions scenario, `y` the year, `j` the SSP-growth model, and `dGMST` is the temperature anomaly relative to the 2001-2010 average. An analogous equation is estimated for the coastal sector with `dGMSL` in place of `dGMST`. These SSP-based damage functions are then emulated for each of the 10,000 RFF-SP draws (see Appendix B of the User Manual), producing the coefficients stored in these files.
+
+**Temperature-driven sectors:**
+```
+damages = beta_anomaly * T + beta_anomaly2 * T^2
+```
+
+**Coastal sector:**
+```
+damages = beta_gmsl * S + beta_gmsl2 * S^2
+```
+
+**CAMEL (combined):**
+```
+damages = beta_anomaly * T + beta_anomaly2 * T^2 + beta_gmsl * S + beta_gmsl2 * S^2
+```
+
+Where:
+- `T` is the global mean surface temperature (GMST) anomaly in Celsius
+- `S` is global mean sea level (GMSL) in centimeters
+- The beta coefficients are the variables stored in the `.nc4` files
+
+The formulas have no intercept, meaning that zero climate change implies zero damages.
+
+
+### Units and baselines
+
+#### Units of the coefficients
+
+The coefficients produce **damages in 2019 PPP-adjusted USD** when multiplied by the climate variables described below. The pipeline then deflates from 2019 to **2020 USD** using the factor `113.648 / 112.29`, applied after evaluating the damage function, not within the coefficient files. For more details on the preprocessing pipeline see the [dscim repository](https://github.com/ClimateImpactLab/dscim).
+
+The coefficients have the following effective units:
+
+| Variable               | Units |
+|------------------------|-------|
+| `anomaly`              | USD per Celsius |
+| `np.power(anomaly, 2)` | USD per Celsius squared |
+| `gmsl`                 | USD per centimeter |
+| `np.power(gmsl, 2)`    | USD per centimeter squared |
+
+USD here refers to 2019 PPP-adjusted U.S. dollars. The resulting damages are total global dollars, not per capita.
+
+#### Climate variable baselines
+
+**GMST anomaly (T):** Celsius, relative to the **2001-2010 mean**. The DSCIM pipeline rebases FaIR temperature output (originally relative to 1765) to this base period. The rebasing is done per simulation: for each of the 10,000 draws, the mean temperature over 2001-2010 is subtracted from the full time series. The relevant code is in `Climate.gmst_anomalies` in [`dscim/menu/simple_storage.py` (v0.5.0)](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py):
+
+```python
+base_period = temps.sel(
+    year=slice(self.base_period[0], self.base_period[1])
+).mean(dim="year")
+anomaly = temps - base_period
+```
+
+where `base_period` defaults to `(2001, 2010)`. If you are bringing your own temperature trajectory (for example from DICE), you need to subtract the mean of your control trajectory over 2001-2010 before applying the coefficients.
+
+**GMSL (S):** Centimeters, relative to the **1991-2009 mean**. No rebasing is applied because the coastal damage estimates are expressed relative to the same period.
+
+> *Note: FACTS outputs are in millimeters and are converted to centimeters by dividing by 10 before being stored in these files. See `Climate.gmsl_anomalies` in [`simple_storage.py`](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py).*
+
+#### Spatial aggregation
+
+The coefficients are globally aggregated (or USA-aggregated for the `_USA` variants). They do not contain a region dimension. The underlying DSCIM model estimates damages at 24,378 impact regions worldwide, but these coefficients are the result of fitting damage functions to the aggregated output.
+
+
+### Damage function weights
+
+The file `damage_function_weights.nc4` contains emulator weights used to weight the 10,000 RFF-SP draws across different socioeconomic modeling assumptions.
+
+#### Structure
+
+| Dimension | Size   | Values |
+|-----------|--------|--------|
+| `model`   | 2      | `IIASA GDP`, `OECD Env-Growth` |
+| `ssp`     | 3      | `SSP2`, `SSP3`, `SSP4` |
+| `rff_sp`  | 10,000 | RFF-SP draw indices (1 to 10,000) |
+| `year`    | 91     | 2010 to 2100 |
+
+The single variable `value` contains the weight for each combination. Weights are non-negative and sum to 1 across the `model` and `ssp` dimensions for each `(rff_sp, year)` pair. These weights were generated by aggregating and interpolating emulator weight CSVs (see the `description` attribute in the file for details).
+
+These weights are not used in the EPA RFF-SP pipeline. The pipeline runs with `fair_aggregation: ["uncollapsed"]`, which uses the 10,000 draws directly without reweighting. The weights file is a holdover from an earlier SSP-based version of the pipeline and can be ignored for standard SC-GHG calculations.
+
+
+### Loading the data
+
+The files can be opened with any NetCDF-compatible library. Using Python and xarray:
+
+```python
+import xarray as xr
+
+# Load CAMEL risk-aversion coefficients for the 2.0% Ramsey discount rate
+ds = xr.open_dataset(
+    "input/damage_functions/CAMEL_m1_c0.20/"
+    "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
+)
+
+# Access coefficients for a specific year and draw
+beta_T  = ds["anomaly"].sel(year=2050, runid=1).values
+beta_T2 = ds["np.power(anomaly, 2)"].sel(year=2050, runid=1).values
+beta_S  = ds["gmsl"].sel(year=2050, runid=1).values
+beta_S2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values
+
+# Compute damages given climate inputs
+T = 2.0   # GMST anomaly in Celsius relative to 2001-2010
+S = 30.0  # GMSL in cm relative to 1991-2009
+damages = beta_T * T + beta_T2 * T**2 + beta_S * S + beta_S2 * S**2
+# Result is in 2019 PPP-adjusted USD (total global damages)
+```
+
+
+### Using the damage functions in other models
+
+Researchers wishing to integrate these damage functions into other models should note the following.
+
+**Climate variable conventions.** Your model's temperature and sea level variables must use the same baselines described above before applying the coefficients. For temperature, subtract the mean of your control trajectory over 2001-2010. For sea level, make sure values are in centimeters relative to 1991-2009.
+
+**Temporal resolution.** Coefficients are provided annually from 2020 to 2300. Each year has its own set of coefficients -- the damage function is not time-invariant. This reflects the fact that the relationship between climate variables and damages evolves as the economy grows and adapts. For years beyond 2300, the simplest approach is to hold the 2300 coefficients constant, though there is no official guidance on extrapolation.
+
+**Probabilistic draws.** The 10,000 `runid` draws represent joint uncertainty in socioeconomic pathways and climate parameters. For a deterministic model run, the mean across draws for each year is the standard approach. For uncertainty analysis, the draws can be sampled or used in a Monte Carlo framework.
+
+**Sector choice.** For aggregate SC-GHG calculations, use the CAMEL files. Individual sector files are useful for understanding the sectoral composition of damages but should not be summed -- the CAMEL coefficients already represent the combined result.
+
+**Recipe choice.** The `risk_aversion` recipe is the primary specification used in the EPA analysis. The `adding_up` recipe is a simpler alternative available only for CAMEL.
+
+The two recipes differ in how local damages are aggregated before the global damage function is estimated. In the `adding_up` (risk-neutral) case, damages across dose-response function draws are averaged within each impact region before summing to the global level. In the `risk_aversion` case, a certainty equivalent (CE) is taken within each of the 24,378 impact regions instead of a mean, using a CRRA utility function with elasticity eta:
+
+```
+CE_cc = [ (1/K) * sum_d( C_d^(1-eta) / (1-eta) ) * (1-eta) ]^(1/(1-eta))
+```
+
+where `C_d = GDPpc - damages_d` is per capita consumption in draw `d`. The difference between the CE under no-climate-change and the CE under climate change gives risk-averse damages, which are larger than the risk-neutral mean because they include a premium for avoiding severe outcomes. This CE is computed at the impact region level (across 24,378 regions globally) before aggregation, not at the global level. See Section 4.1.2 and Appendix A of the DSCIM User Manual (September 2022) for the full derivation.
+
+**Currency conversion.** The coefficients produce damages in 2019 PPP-adjusted USD. Apply a deflator if your model uses a different base year. The DSCIM-FACTS-EPA pipeline uses `113.648 / 112.29` to convert from 2019 to 2020 USD. This deflator is applied after evaluating the damage function, not within the coefficient files.
+
+**Computing marginal damages for the SC-GHG.** To compute the SC-GHG, evaluate the damage function under both a control (no-pulse) and pulse climate trajectory, take the difference (marginal damages), discount the stream, and sum. A minimal example:
+
+```python
+import xarray as xr
+
+ds = xr.open_dataset(
+    "input/damage_functions/CAMEL_m1_c0.20/"
+    "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
+).squeeze("discount_type", drop=True)
+
+def eval_damages(T, S, ds):
+    b1 = ds["anomaly"]
+    b2 = ds["np.power(anomaly, 2)"]
+    b3 = ds["gmsl"]
+    b4 = ds["np.power(gmsl, 2)"]
+    return b1 * T + b2 * T**2 + b3 * S + b4 * S**2
+
+# T_control, T_pulse: xr.DataArray with a 'year' dimension
+# S_control, S_pulse: same, in cm relative to 1991-2009
+# Both T arrays must be rebased to the 2001-2010 mean of the control trajectory
+
+damages_control = eval_damages(T_control, S_control, ds)
+damages_pulse   = eval_damages(T_pulse,   S_pulse,   ds)
+
+# Marginal damages: shape (year, runid)
+marginal_damages = damages_pulse - damages_control
+
+# Collapse across draws for a deterministic analysis
+marginal_damages_mean = marginal_damages.mean("runid")
+
+# Convert to 2020 USD
+marginal_damages_2020usd = marginal_damages_mean * (113.648 / 112.29)
+```
+
+The gas-specific pulse conversion factors are defined in the run configuration (see `gas_conversions` in the generated config file). The default CO2 pulse conversion is `2.72916487e-10`, which converts a 1 GtC pulse to per-tonne-CO2 units.

--- a/README.md
+++ b/README.md
@@ -458,15 +458,16 @@ Damage Functions
 
 ## Damage function coefficients
 
-This section describes the pre-computed damage function coefficients for computing the Social Cost of Greenhouse Gases (SC-GHG) with DSCIM-FACTS-EPA. The coefficients are quadratic regressions of globally-aggregated climate damages on temperature and sea level, estimated year by year across 10,000 probabilistic socioeconomic-climate draws.
+The `input/damage_functions/` directory contains pre-computed damage function coefficients used to translate climate projections into monetized damages. The coefficients are quadratic regressions of globally-aggregated climate damages on temperature and sea level, estimated year by year across 10,000 probabilistic socioeconomic-climate draws.
+
+For details on units, climate variable baselines, discounting, recipe definitions, and guidance on integrating the coefficients into other models, see the companion documentation in [`DAMAGE_FUNCTIONS.md`](DAMAGE_FUNCTIONS.md).
+
 
 ### Directory structure
 
 ```
 damage_functions/
-|
-|-- damage_function_weights.nc4       # Emulator weights (see below)
-|
+|-- damage_function_weights.nc4       # Emulator weights
 |-- CAMEL_m1_c0.20/                   # Combined sector, global
 |-- CAMEL_m1_c0.20_USA/               # Combined sector, USA
 |-- agriculture/                      # Agriculture, global
@@ -479,46 +480,14 @@ damage_functions/
 |-- labor_USA/                        # Labor, USA
 |-- mortality_v1/                     # Mortality, global
 |-- mortality_v1_USA/                 # Mortality, USA
-|-- google_download/                  # (empty placeholder directories)
 ```
 
-Each sector directory contains NetCDF4 files with damage function coefficients for different combinations of valuation recipe and Ramsey discount rate parameters.
+**CAMEL** (Coastal, Agriculture, Mortality, Energy, Labor) is the combined multi-sector aggregate and the primary output for computing SC-GHGs. The suffix `m1_c0.20` indicates mortality version 1 and coastal version 0.20. Mortality v1 uses VSL (Value of Statistical Life) valuation with ISO-level deaths and impact-region-level costs, and is the EPA main specification. Coastal v0.20 is the original EPA specification using FACTS-based sea level projections (Kopp et al. 2023). Each sector also has a `_USA` variant for territorial U.S. damages.
 
 
-### Sectors
+### File naming and parameters
 
-| Directory name     | Description |
-|--------------------|-------------|
-| `agriculture`      | Agricultural productivity damages |
-| `coastal_v0.20`    | Coastal damages from sea level rise (version 0.20) |
-| `energy`           | Energy expenditure damages (heating and cooling) |
-| `labor`            | Labor productivity damages |
-| `mortality_v1`     | Mortality damages (version 1) |
-| `CAMEL_m1_c0.20`   | **Combined**: all five sectors above, aggregated |
-
-**CAMEL** stands for Coastal, Agriculture, Mortality, Energy, and Labor. The suffix `m1_c0.20` indicates mortality version 1 and coastal version 0.20. Mortality v1 uses VSL (Value of Statistical Life) valuation with ISO-level deaths and impact-region-level costs -- this is the EPA main specification. Coastal v0.20 is the original EPA specification using FACTS-based sea level projections (Kopp et al. 2023). CAMEL is the primary output for computing aggregate SC-GHGs.
-
-Each sector has a `_USA` variant containing coefficients for damages restricted to the United States, used for computing territorial U.S. SC-GHGs.
-
-
-### File naming convention
-
-Files follow this pattern:
-
-```
-{recipe}_euler_ramsey_eta{eta}_rho{rho}_dfc.nc4
-```
-
-Where:
-
-- **recipe**: The valuation approach. Either `risk_aversion` or `adding_up`.
-  - `risk_aversion`: Certainty-equivalent damages accounting for risk aversion across climate and socioeconomic uncertainty. This is the primary recipe used in the EPA specification.
-  - `adding_up`: A simpler approach that sums damages across regions without certainty-equivalent adjustments. Only available for the CAMEL sector.
-- **euler_ramsey**: The discounting framework (Euler equation with Ramsey discounting). All files use this framework.
-- **eta**: Elasticity of marginal utility of consumption (the concavity of the CRRA utility function).
-- **rho**: Pure rate of time preference.
-
-#### Available parameter combinations
+Files follow the pattern `{recipe}_euler_ramsey_eta{eta}_rho{rho}_dfc.nc4`, where `recipe` is either `risk_aversion` (primary EPA specification) or `adding_up` (CAMEL only).
 
 | Near-term discount rate | eta     | rho     |
 |------------------------|---------|---------|
@@ -527,230 +496,44 @@ Where:
 | 2.5% Ramsey            | 1.421   | 0.005   |
 | 3.0% Ramsey            | 1.568   | 0.008   |
 
-These four (eta, rho) pairs correspond to the near-term certainty-equivalent discount rates described in the EPA technical report. The label (e.g. "2.0% Ramsey") is approximate and used for identification only. The actual discount rate applied in each draw varies over time because it is computed from the realized consumption growth rate of that draw, following stochastic Ramsey discounting (Section 5.1 of the DSCIM User Manual, eq. 11):
 
-```
-SDF_ky = product over tau from u to y of exp( -(rho + eta * g_c_k_tau) )
-```
+### Data variables
 
-where `g_c_k_tau = ln(c_k_tau / c_k_tau-1)` is the consumption growth rate of draw `k` in year `tau`, and `c_k_tau` is global GDP minus climate damages in that draw and year. This is implemented in `scghg_utils.py` via `menu_item_global.uncollapsed_discount_factors`, which uses the draw-specific GDP path net of damages rather than a fixed rate.
+Each `.nc4` file has dimensions `year` (2020 to 2300), `runid` (1 to 10,000), and `discount_type` (1). The data variables are:
 
-
-### Data structure of coefficient files
-
-Each `.nc4` file is a NetCDF4 dataset with the following structure.
-
-#### Dimensions
-
-| Dimension        | Size   | Description |
-|-----------------|--------|-------------|
-| `discount_type` | 1      | Discounting framework (always `"euler_ramsey"`) |
-| `year`          | 281    | Year of the damage function, from 2020 to 2300 |
-| `runid`         | 10,000 | RFF socioeconomic pathway draw index (1 to 10,000) |
-
-Each `runid` corresponds to one draw from the joint distribution of socioeconomic projections (from the Resources for the Future Socioeconomic Pathways, RFF-SPv2) and climate model parameters (from FaIR). The mapping between `runid` and underlying scenario parameters is documented in the EPA technical report.
-
-#### Variables
-
-The data variables are the regression coefficients of the damage function. Their names correspond to the terms in the regression formula.
-
-**Temperature-driven sectors** (agriculture, energy, labor, mortality):
-
-| Variable               | Description |
-|------------------------|-------------|
-| `anomaly`              | Coefficient on the linear GMST anomaly term |
-| `np.power(anomaly, 2)` | Coefficient on the squared GMST anomaly term |
-
-**Coastal sector** (coastal_v0.20):
-
-| Variable               | Description |
-|------------------------|-------------|
-| `gmsl`                 | Coefficient on the linear GMSL term |
-| `np.power(gmsl, 2)`    | Coefficient on the squared GMSL term |
-
-**Combined sector** (CAMEL_m1_c0.20):
-
-| Variable               | Description |
-|------------------------|-------------|
-| `anomaly`              | Coefficient on the linear GMST anomaly term |
-| `np.power(anomaly, 2)` | Coefficient on the squared GMST anomaly term |
-| `gmsl`                 | Coefficient on the linear GMSL term |
-| `np.power(gmsl, 2)`    | Coefficient on the squared GMSL term |
+| Variable               | Sectors | Description |
+|------------------------|---------|-------------|
+| `anomaly`              | Temperature-driven, CAMEL | Linear GMST coefficient |
+| `np.power(anomaly, 2)` | Temperature-driven, CAMEL | Quadratic GMST coefficient |
+| `gmsl`                 | Coastal, CAMEL | Linear GMSL coefficient |
+| `np.power(gmsl, 2)`    | Coastal, CAMEL | Quadratic GMSL coefficient |
 
 
-### Formulas
+### Computing damages
 
-The damage functions are quadratic regressions (without intercept) of global damages on climate variables. For each sector, year, and SSP-growth model combination, the damage function is estimated by OLS across the 33 GCMs and 2 RCP emissions scenarios (Section 4.2 of the DSCIM User Manual, eq. 4):
+The damage functions are quadratic regressions without intercept. For CAMEL:
 
-```
-damages_slpyj = beta1_syj * dGMST_ylp + beta2_syj * dGMST_ylp^2 + error
-```
-
-where `l` indexes the climate model, `p` the emissions scenario, `y` the year, `j` the SSP-growth model, and `dGMST` is the temperature anomaly relative to the 2001-2010 average. An analogous equation is estimated for the coastal sector with `dGMSL` in place of `dGMST`. These SSP-based damage functions are then emulated for each of the 10,000 RFF-SP draws (see Appendix B of the User Manual), producing the coefficients stored in these files.
-
-**Temperature-driven sectors:**
-```
-damages = beta_anomaly * T + beta_anomaly2 * T^2
-```
-
-**Coastal sector:**
-```
-damages = beta_gmsl * S + beta_gmsl2 * S^2
-```
-
-**CAMEL (combined):**
 ```
 damages = beta_anomaly * T + beta_anomaly2 * T^2 + beta_gmsl * S + beta_gmsl2 * S^2
 ```
 
-Where:
-- `T` is the global mean surface temperature (GMST) anomaly in Celsius
-- `S` is global mean sea level (GMSL) in centimeters
-- The beta coefficients are the variables stored in the `.nc4` files
-
-The formulas have no intercept, meaning that zero climate change implies zero damages.
-
-
-### Units and baselines
-
-#### Units of the coefficients
-
-The coefficients produce **damages in 2019 PPP-adjusted USD** when multiplied by the climate variables described below. The pipeline then deflates from 2019 to **2020 USD** using the factor `113.648 / 112.29`, applied after evaluating the damage function, not within the coefficient files. For more details on the preprocessing pipeline see the [dscim repository](https://github.com/ClimateImpactLab/dscim).
-
-The coefficients have the following effective units:
-
-| Variable               | Units |
-|------------------------|-------|
-| `anomaly`              | USD per Celsius |
-| `np.power(anomaly, 2)` | USD per Celsius squared |
-| `gmsl`                 | USD per centimeter |
-| `np.power(gmsl, 2)`    | USD per centimeter squared |
-
-USD here refers to 2019 PPP-adjusted U.S. dollars. The resulting damages are total global dollars, not per capita.
-
-#### Climate variable baselines
-
-**GMST anomaly (T):** Celsius, relative to the **2001-2010 mean**. The DSCIM pipeline rebases FaIR temperature output (originally relative to 1765) to this base period. The rebasing is done per simulation: for each of the 10,000 draws, the mean temperature over 2001-2010 is subtracted from the full time series. The relevant code is in `Climate.gmst_anomalies` in [`dscim/menu/simple_storage.py` (v0.5.0)](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py):
-
-```python
-base_period = temps.sel(
-    year=slice(self.base_period[0], self.base_period[1])
-).mean(dim="year")
-anomaly = temps - base_period
-```
-
-where `base_period` defaults to `(2001, 2010)`. If you are bringing your own temperature trajectory (for example from DICE), you need to subtract the mean of your control trajectory over 2001-2010 before applying the coefficients.
-
-**GMSL (S):** Centimeters, relative to the **1991-2009 mean**. No rebasing is applied because the coastal damage estimates are expressed relative to the same period.
-
-> *Note: FACTS outputs are in millimeters and are converted to centimeters by dividing by 10 before being stored in these files. See `Climate.gmsl_anomalies` in [`simple_storage.py`](https://github.com/ClimateImpactLab/dscim/blob/v0.5.0/src/dscim/menu/simple_storage.py).*
-
-#### Spatial aggregation
-
-The coefficients are globally aggregated (or USA-aggregated for the `_USA` variants). They do not contain a region dimension. The underlying DSCIM model estimates damages at 24,378 impact regions worldwide, but these coefficients are the result of fitting damage functions to the aggregated output.
-
-
-### Damage function weights
-
-The file `damage_function_weights.nc4` contains emulator weights used to weight the 10,000 RFF-SP draws across different socioeconomic modeling assumptions.
-
-#### Structure
-
-| Dimension | Size   | Values |
-|-----------|--------|--------|
-| `model`   | 2      | `IIASA GDP`, `OECD Env-Growth` |
-| `ssp`     | 3      | `SSP2`, `SSP3`, `SSP4` |
-| `rff_sp`  | 10,000 | RFF-SP draw indices (1 to 10,000) |
-| `year`    | 91     | 2010 to 2100 |
-
-The single variable `value` contains the weight for each combination. Weights are non-negative and sum to 1 across the `model` and `ssp` dimensions for each `(rff_sp, year)` pair. These weights were generated by aggregating and interpolating emulator weight CSVs (see the `description` attribute in the file for details).
-
-These weights are not used in the EPA RFF-SP pipeline. The pipeline runs with `fair_aggregation: ["uncollapsed"]`, which uses the 10,000 draws directly without reweighting. The weights file is a holdover from an earlier SSP-based version of the pipeline and can be ignored for standard SC-GHG calculations.
-
-
-### Loading the data
-
-The files can be opened with any NetCDF-compatible library. Using Python and xarray:
+where `T` is GMST anomaly in Celsius (relative to 2001-2010) and `S` is GMSL in centimeters (relative to 1991-2009). The result is in 2019 PPP-adjusted USD.
 
 ```python
 import xarray as xr
 
-# Load CAMEL risk-aversion coefficients for the 2.0% Ramsey discount rate
 ds = xr.open_dataset(
     "input/damage_functions/CAMEL_m1_c0.20/"
     "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
 )
 
-# Access coefficients for a specific year and draw
 beta_T  = ds["anomaly"].sel(year=2050, runid=1).values
 beta_T2 = ds["np.power(anomaly, 2)"].sel(year=2050, runid=1).values
 beta_S  = ds["gmsl"].sel(year=2050, runid=1).values
 beta_S2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values
 
-# Compute damages given climate inputs
 T = 2.0   # GMST anomaly in Celsius relative to 2001-2010
 S = 30.0  # GMSL in cm relative to 1991-2009
 damages = beta_T * T + beta_T2 * T**2 + beta_S * S + beta_S2 * S**2
-# Result is in 2019 PPP-adjusted USD (total global damages)
+# Result is in 2019 PPP-adjusted USD
 ```
-
-
-### Using the damage functions in other models
-
-Researchers wishing to integrate these damage functions into other models should note the following.
-
-**Climate variable conventions.** Your model's temperature and sea level variables must use the same baselines described above before applying the coefficients. For temperature, subtract the mean of your control trajectory over 2001-2010. For sea level, make sure values are in centimeters relative to 1991-2009.
-
-**Temporal resolution.** Coefficients are provided annually from 2020 to 2300. Each year has its own set of coefficients -- the damage function is not time-invariant. This reflects the fact that the relationship between climate variables and damages evolves as the economy grows and adapts. For years beyond 2300, the simplest approach is to hold the 2300 coefficients constant, though there is no official guidance on extrapolation.
-
-**Probabilistic draws.** The 10,000 `runid` draws represent joint uncertainty in socioeconomic pathways and climate parameters. For a deterministic model run, the mean across draws for each year is the standard approach. For uncertainty analysis, the draws can be sampled or used in a Monte Carlo framework.
-
-**Sector choice.** For aggregate SC-GHG calculations, use the CAMEL files. Individual sector files are useful for understanding the sectoral composition of damages but should not be summed -- the CAMEL coefficients already represent the combined result.
-
-**Recipe choice.** The `risk_aversion` recipe is the primary specification used in the EPA analysis. The `adding_up` recipe is a simpler alternative available only for CAMEL.
-
-The two recipes differ in how local damages are aggregated before the global damage function is estimated. In the `adding_up` (risk-neutral) case, damages across dose-response function draws are averaged within each impact region before summing to the global level. In the `risk_aversion` case, a certainty equivalent (CE) is taken within each of the 24,378 impact regions instead of a mean, using a CRRA utility function with elasticity eta:
-
-```
-CE_cc = [ (1/K) * sum_d( C_d^(1-eta) / (1-eta) ) * (1-eta) ]^(1/(1-eta))
-```
-
-where `C_d = GDPpc - damages_d` is per capita consumption in draw `d`. The difference between the CE under no-climate-change and the CE under climate change gives risk-averse damages, which are larger than the risk-neutral mean because they include a premium for avoiding severe outcomes. This CE is computed at the impact region level (across 24,378 regions globally) before aggregation, not at the global level. See Section 4.1.2 and Appendix A of the DSCIM User Manual (September 2022) for the full derivation.
-
-**Currency conversion.** The coefficients produce damages in 2019 PPP-adjusted USD. Apply a deflator if your model uses a different base year. The DSCIM-FACTS-EPA pipeline uses `113.648 / 112.29` to convert from 2019 to 2020 USD. This deflator is applied after evaluating the damage function, not within the coefficient files.
-
-**Computing marginal damages for the SC-GHG.** To compute the SC-GHG, evaluate the damage function under both a control (no-pulse) and pulse climate trajectory, take the difference (marginal damages), discount the stream, and sum. A minimal example:
-
-```python
-import xarray as xr
-
-ds = xr.open_dataset(
-    "input/damage_functions/CAMEL_m1_c0.20/"
-    "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
-).squeeze("discount_type", drop=True)
-
-def eval_damages(T, S, ds):
-    b1 = ds["anomaly"]
-    b2 = ds["np.power(anomaly, 2)"]
-    b3 = ds["gmsl"]
-    b4 = ds["np.power(gmsl, 2)"]
-    return b1 * T + b2 * T**2 + b3 * S + b4 * S**2
-
-# T_control, T_pulse: xr.DataArray with a 'year' dimension
-# S_control, S_pulse: same, in cm relative to 1991-2009
-# Both T arrays must be rebased to the 2001-2010 mean of the control trajectory
-
-damages_control = eval_damages(T_control, S_control, ds)
-damages_pulse   = eval_damages(T_pulse,   S_pulse,   ds)
-
-# Marginal damages: shape (year, runid)
-marginal_damages = damages_pulse - damages_control
-
-# Collapse across draws for a deterministic analysis
-marginal_damages_mean = marginal_damages.mean("runid")
-
-# Convert to 2020 USD
-marginal_damages_2020usd = marginal_damages_mean * (113.648 / 112.29)
-```
-
-The gas-specific pulse conversion factors are defined in the run configuration (see `gas_conversions` in the generated config file). The default CO2 pulse conversion is `2.72916487e-10`, which converts a 1 GtC pulse to per-tonne-CO2 units.

--- a/README.md
+++ b/README.md
@@ -458,9 +458,9 @@ Damage Functions
 
 ## Damage function coefficients
 
-The `input/damage_functions/` directory contains pre-computed damage function coefficients used to translate climate projections into monetized damages. The coefficients are quadratic regressions of globally-aggregated climate damages on temperature and sea level, estimated year by year across 10,000 probabilistic socioeconomic-climate draws.
+The `input/damage_functions/` directory contains pre-computed damage function coefficients used to translate climate projections into monetized damages. The coefficients are quadratic regressions of globally- or sub-globally-aggregated climate damages on global mean temperature and sea level, estimated for each year and socioeconomics pathway**. (**Note, damage functions are initially estimated on damages based on Shared Socioeconomic Pathways, or SSPs. Those damage functions are then used to emulate damage functions for Resources for the Future Socioeconomic Pathways, or RFF-SPs, provided here).
 
-For details on units, climate variable baselines, discounting, recipe definitions, and guidance on integrating the coefficients into other models, see the companion documentation in [`DAMAGE_FUNCTIONS.md`](DAMAGE_FUNCTIONS.md).
+For references and details on units, climate variable baselines, recipe definitions, and guidance on using the coefficients, see the companion documentation in [`DAMAGE_FUNCTIONS.md`](DAMAGE_FUNCTIONS.md).
 
 
 ### Directory structure
@@ -468,8 +468,8 @@ For details on units, climate variable baselines, discounting, recipe definition
 ```
 damage_functions/
 |-- damage_function_weights.nc4       # Emulator weights
-|-- CAMEL_m1_c0.20/                   # Combined sector, global
-|-- CAMEL_m1_c0.20_USA/               # Combined sector, USA
+|-- CAMEL_m1_c0.20/                   # Combined sectors, global
+|-- CAMEL_m1_c0.20_USA/               # Combined sectors, USA
 |-- agriculture/                      # Agriculture, global
 |-- agriculture_USA/                  # Agriculture, USA
 |-- coastal_v0.20/                    # Coastal, global
@@ -482,26 +482,19 @@ damage_functions/
 |-- mortality_v1_USA/                 # Mortality, USA
 ```
 
-**CAMEL** (Coastal, Agriculture, Mortality, Energy, Labor) is the combined multi-sector aggregate and the primary output for computing SC-GHGs. The suffix `m1_c0.20` indicates mortality version 1 and coastal version 0.20. Mortality v1 uses VSL (Value of Statistical Life) valuation with ISO-level deaths and impact-region-level costs, and is the EPA main specification. Coastal v0.20 is the original EPA specification using FACTS-based sea level projections (Kopp et al. 2023). Each sector also has a `_USA` variant for territorial U.S. damages.
+**CAMEL** (Coastal, Agriculture, Mortality, Energy, Labor) is the combined multi-sector aggregate and the primary output for computing SC-GHGs. The suffix `m1_c0.20` indicates specific mortality and coastal versions used in the main EPA specification here. Each sector also has a `_USA` variant for territorial U.S. damages.
 
 
 ### File naming and parameters
 
-Files follow the pattern `{recipe}_euler_ramsey_eta{eta}_rho{rho}_dfc.nc4`, where `recipe` is either `risk_aversion` (primary EPA specification) or `adding_up` (CAMEL only).
-
-| Near-term discount rate | eta     | rho     |
-|------------------------|---------|---------|
-| 1.5% Ramsey            | 1.016   | 0.0     |
-| 2.0% Ramsey            | 1.244   | 0.002   |
-| 2.5% Ramsey            | 1.421   | 0.005   |
-| 3.0% Ramsey            | 1.568   | 0.008   |
+Files follow the pattern `{recipe}_euler_ramsey_eta{eta}_rho{rho}_dfc.nc4`, where `recipe` is either `risk_aversion` (primary EPA specification) or `adding_up` (CAMEL only). `risk_aversion` damage functions include the price of uncertainty in the underlying statistical relationships between impact region damages and weather, whereas `adding_up` damage functions do not (they are risk neutral). NOTE: `euler_ramsey` and `rho` in the filenames can be ignored - damage functions do not vary by these traits. `eta` can additionally be ignored in the `adding_up` filenames for the same reason - those damage functions do not vary by `eta`.
 
 
 ### Data variables
 
 Each `.nc4` file has dimensions `year` (2020 to 2300), `runid` (1 to 10,000), and `discount_type` (1). The data variables are:
 
-| Variable               | Sectors | Description |
+| Variable Name          | Sectors | Description |
 |------------------------|---------|-------------|
 | `anomaly`              | Temperature-driven, CAMEL | Linear GMST coefficient |
 | `np.power(anomaly, 2)` | Temperature-driven, CAMEL | Quadratic GMST coefficient |
@@ -514,10 +507,10 @@ Each `.nc4` file has dimensions `year` (2020 to 2300), `runid` (1 to 10,000), an
 The damage functions are quadratic regressions without intercept. For CAMEL:
 
 ```
-damages = beta_anomaly * T + beta_anomaly2 * T^2 + beta_gmsl * S + beta_gmsl2 * S^2
+damages = beta_gmst * T + beta_gmst2 * T^2 + beta_gmsl * S + beta_gmsl2 * S^2
 ```
 
-where `T` is GMST anomaly in Celsius (relative to 2001-2010) and `S` is GMSL in centimeters (relative to 1991-2009). The result is in 2019 PPP-adjusted USD.
+where `T` is GMST anomaly in Celsius (relative to 2001-2010) and `S` is GMSL in centimeters (relative to 1991-2009). The result is in 2019 PPP-adjusted USD. Here's an example of calculating CAMEL damages for one year and one RFF-SP-climate draw (`runid`), given a GMST and GMSL value:
 
 ```python
 import xarray as xr
@@ -527,13 +520,15 @@ ds = xr.open_dataset(
     "risk_aversion_euler_ramsey_eta1.244_rho0.002_dfc.nc4"
 )
 
-beta_T  = ds["anomaly"].sel(year=2050, runid=1).values
-beta_T2 = ds["np.power(anomaly, 2)"].sel(year=2050, runid=1).values
-beta_S  = ds["gmsl"].sel(year=2050, runid=1).values
-beta_S2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values
+# select one year and one runid from the damage function coefficients 
+# to demonstrate the damage calculation
+beta_gmst  = ds["anomaly"].sel(year=2050, runid=1).values
+beta_gmst2 = ds["np.power(anomaly, 2)"].sel(year=2050, runid=1).values
+beta_gmsl  = ds["gmsl"].sel(year=2050, runid=1).values
+beta_gmsl2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values
 
 T = 2.0   # GMST anomaly in Celsius relative to 2001-2010
 S = 30.0  # GMSL in cm relative to 1991-2009
-damages = beta_T * T + beta_T2 * T**2 + beta_S * S + beta_S2 * S**2
+damages = beta_gmst * T + beta_gmst2 * T**2 + beta_gmsl * S + beta_gmsl2 * S**2
 # Result is in 2019 PPP-adjusted USD
 ```

--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ where `T` is GMST anomaly in Celsius (relative to 2001-2010) and `S` is GMSL in 
 
 ```python
 import xarray as xr
+import numpy as np
 
 ds = xr.open_dataset(
     "input/damage_functions/CAMEL_m1_c0.20/"
@@ -529,6 +530,6 @@ beta_gmsl2 = ds["np.power(gmsl, 2)"].sel(year=2050, runid=1).values
 
 T = 2.0   # GMST anomaly in Celsius relative to 2001-2010
 S = 30.0  # GMSL in cm relative to 1991-2009
-damages = beta_gmst * T + beta_gmst2 * T**2 + beta_gmsl * S + beta_gmsl2 * S**2
+damages = beta_gmst * T + beta_gmst2 * np.power(T, 2) + beta_gmsl * S + beta_gmsl2 * np.power(S, 2)
 # Result is in 2019 PPP-adjusted USD
 ```

--- a/README.md
+++ b/README.md
@@ -460,8 +460,6 @@ Damage Functions
 
 This section describes the pre-computed damage function coefficients for computing the Social Cost of Greenhouse Gases (SC-GHG) with DSCIM-FACTS-EPA. The coefficients are quadratic regressions of globally-aggregated climate damages on temperature and sea level, estimated year by year across 10,000 probabilistic socioeconomic-climate draws.
 
-For methodological details, see [References](#references).
-
 ### Directory structure
 
 ```


### PR DESCRIPTION
Add documentation describing the precomputed damage function coefficients, including file structure, variable definitions, units, climate baselines, and simple usage examples. Provide a summary in `README.md`, and additional details in `DAMAGE_FUNCTIONS.md`.